### PR TITLE
Add ability to send remote key presses with lirc by publishing to MQTT topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LIRC watcher
 ![Docker Build](https://github.com/pilotak/docker-lirc-watcher/workflows/docker%20build/badge.svg) ![Docker Pulls](https://img.shields.io/docker/pulls/pilotak/lirc-watcher) ![Docker Size](https://img.shields.io/docker/image-size/pilotak/lirc-watcher?color=orange)
 
-Docker container that listens to LIRC daemon (running on the host) and sends received codes over MQTT with added benefit of short and long putton press.
+Docker container that listens to LIRC daemon (running on the host) and sends received codes over MQTT with added benefit of short and long putton press. It can also send IR remote keys through lirc by publishing to MQTT topics.
 
 **LIRC must be install on the host system**. Following examples have been tested below but should work on other platforms with adjustments too.
 
@@ -116,6 +116,9 @@ Bellow are all available variables
 | `MQTT_PREFIX` | MQTT topic prefix | "lirc" |
 | `MQTT_QOS` | MQTT QOS | 1 |
 
-### MQTT topics
+### MQTT topics for receiving
 When button is pressed you will receive message in format
 `MQTT_PREFIX/REMOTE_NAME/KEY_NAME` with payload `short` / `long` ie. `lirc/pioneer/KEY_POWER`
+
+### MQTT topics for sending
+To send a remote key press, publish to `MQTT_PREFIX/send/REMOTE_NAME/KEY_NAME` with the payload being the number of repeats ie. `lirc/send/pioneer/KEY_POWER` If the payload is empty, repeats will default to 1.

--- a/lirc_watcher.py
+++ b/lirc_watcher.py
@@ -21,6 +21,7 @@ MQTT_PORT = os.getenv('MQTT_PORT', 1883)
 MQTT_ID = os.getenv('MQTT_ID', 'lirc-watcher')
 MQTT_PREFIX = os.getenv('MQTT_PREFIX', 'lirc')
 
+MQTT_SEND_TOPIC = '%s/send/#' % MQTT_PREFIX
 MQTT_STATUS_TOPIC = '%s/alive' % MQTT_PREFIX
 MQTT_PAYLOAD_ONLINE = '1'
 MQTT_PAYLOAD_OFFLINE = '0'
@@ -34,15 +35,29 @@ def on_mqtt_connect(mqtt, userdata, flags, rc):
 
         mqtt.publish(MQTT_STATUS_TOPIC, payload=MQTT_PAYLOAD_ONLINE,
                      qos=MQTT_QOS, retain=True)
+        mqtt.subscribe(MQTT_SEND_TOPIC)
     else:
         print('MQTT connect failed:', rc)
 
+def on_mqtt_message(client, userdata, msg):
+    try:
+        (remote, key) = str(msg.topic).split("/")[-2:]
+        try:
+            repeat = int(msg.payload)
+        except:
+            repeat = 1
+        command = "SEND_ONCE %s %s %d\n" % (remote, key, repeat)
+        print(command)
+        sock.sendall(command.encode("utf-8"))
+    except:
+        print(str(msg.topic))
 
 prev_data = None
 timer = None
 
 mqtt = paho.Client(MQTT_ID)
 mqtt.on_connect = on_mqtt_connect
+mqtt.on_message = on_mqtt_message
 mqtt.will_set(MQTT_STATUS_TOPIC, payload=MQTT_PAYLOAD_OFFLINE,
               qos=MQTT_QOS, retain=True)
 mqtt.username_pw_set(MQTT_USER, MQTT_PASSWORD)
@@ -52,7 +67,6 @@ mqtt.loop_start()
 sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 sock.connect("/var/run/lirc/lircd")
 fcntl.fcntl(sock, fcntl.F_SETFL, os.O_NONBLOCK)
-
 
 def send_code(priority_data=None):
     global prev_data, mqtt, timer
@@ -111,19 +125,21 @@ try:
                 print("new_data: ", new_data)
                 counter_str = new_data.split()
 
-                """
-                If we received new_data and prev_data was not sent
-                """
-                if prev_data is not None and int(counter_str[1], 16) == 0:
-                    send_code(prev_data)
+                #ignore the status return from lirc sends
+                if counter_str[0] != "BEGIN":
+                    """
+                    If we received new_data and prev_data was not sent
+                    """
+                    if prev_data is not None and int(counter_str[1], 16) == 0:
+                        send_code(prev_data)
 
-                prev_data = new_data
+                    prev_data = new_data
 
-                if timer is not None and timer.is_alive():
-                    timer.cancel()
+                    if timer is not None and timer.is_alive():
+                        timer.cancel()
 
-                timer = Timer(READ_TIMEOUT, send_code)
-                timer.start()
+                    timer = Timer(READ_TIMEOUT, send_code)
+                    timer.start()
 
 
 except KeyboardInterrupt:

--- a/lirc_watcher.py
+++ b/lirc_watcher.py
@@ -68,6 +68,7 @@ sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 sock.connect("/var/run/lirc/lircd")
 fcntl.fcntl(sock, fcntl.F_SETFL, os.O_NONBLOCK)
 
+
 def send_code(priority_data=None):
     global prev_data, mqtt, timer
 


### PR DESCRIPTION
My hardware can support sending IR signals (blasting). LIRC can send remote key presses, so I added a subscription to allow the sending of those keys through MQTT.

The user just needs to publish to MQTT_PREFIX/send/REMOTE/KEY with an optional payload for the number of key repeats to send. The container sends a SEND_ONCE command to LIRC when it receives the MQTT message.

LIRC returns the success or reason for failure if it cannot send (if for example the remote or key aren't found). For now, the code is discarding that status return (I didn't have a need for it).